### PR TITLE
updating to avoid an entire file of syntax errors in vscode

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Oh you use typescript too? Cool. You'll want to follow these steps:
 + `import {GrabTypings} from 'grab-typings'`
 + `new GrabTypings().run(['array','of','args'])` which will return a promise
 
-That's it. see [lib/grab-typings.ts](./lib/grab-typings.ts) for an example.
+That's it. see [lib/grab-typings.ts](./lib/grab-typings-logic.ts) for an example.
 
 # License
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,6 +35,8 @@ gulp.task('compile:lib', ['cleanup:dest'], function() {
                 path.basename = "grab-typings.d";
             } else if (path.basename === 'grab-typings.d') {
                 path.basename = "cli.d";
+            } else if (path.basename === 'grab-typings-logic.d') {
+                path.basename = "cli-logic.d";
             }
         }))
         .pipe(replace(/\/\/\/\s<reference path=\"(.+)\"/g, function (matched, thing1) {

--- a/lib/grab-typings-logic.ts
+++ b/lib/grab-typings-logic.ts
@@ -1,0 +1,33 @@
+/// <reference path="../typings/chalk/chalk.d.ts" />
+/// <reference path="../typings/node/node.d.ts" />
+
+import * as GT from './';
+import * as chalk from 'chalk';
+
+/**
+ * A simple little command line version, exported as function
+ * to make vscode syntax highlighting happier (now it's only
+ * sad in grab-typings.ts which is nearly empty) - this makes
+ * me happier when i develop the codes, so it's totally worth.
+ */
+export function logic() {
+    new GT.GrabTypings().run(process.argv.slice(2)).then((rr : GT.RunResult) => {
+        
+        // totall installed/total
+        console.log(rr.installed.length+"/"+(rr.missing.length+rr.installed.length));
+        
+        rr.installed.forEach((m : string) => {
+            // checkmark <module>
+            console.log(chalk.green("\u2713 ")+m);
+        });
+        rr.warnings.forEach((message : string) => {
+            console.warn(chalk.yellow(message));
+        });
+        rr.missing.forEach((m : string) => {
+            // x <module>
+            console.error(chalk.red("\u2718 ")+m);
+        });
+    }, (err : any) => {
+        console.error("Oops - something went wrong...", err);
+    });
+};

--- a/lib/grab-typings.ts
+++ b/lib/grab-typings.ts
@@ -1,29 +1,6 @@
 #!/usr/bin/env node
-/// <reference path="../typings/chalk/chalk.d.ts" />
-/// <reference path="../typings/node/node.d.ts" />
+import * as Cli from './grab-typings';
 
-import * as GT from './';
-import * as chalk from 'chalk';
-
-/**
- * A simple little command line version
- */
-new GT.GrabTypings().run(process.argv.slice(2)).then((rr : GT.RunResult) => {
-    
-    // totall installed/total
-    console.log(rr.installed.length+"/"+(rr.missing.length+rr.installed.length));
-    
-    rr.installed.forEach((m : string) => {
-        // checkmark <module>
-        console.log(chalk.green("\u2713 ")+m);
-    });
-    rr.warnings.forEach((message : string) => {
-        console.warn(chalk.yellow(message));
-    });
-    rr.missing.forEach((m : string) => {
-        // x <module>
-        console.error(chalk.red("\u2718 ")+m);
-    });
-}, (err : any) => {
-    console.error("Oops - something went wrong...", err);
-});
+// This is because i was raging having the Cli file have syntax
+// highlighting errors in vscode - so now we don't have that.
+Cli.logic();


### PR DESCRIPTION
due to a vscode bug, the `grab-typings.ts` file was flagging syntax errors - since i hate seeing those when i open the project, i pulled the logic for the cli into a seperate file that has no errors, exported the behavior as a function `logic` and call into `logic` from the failing file. now i basically never need to look at the syntax errors.
