### PR TITLE
Swap the order of the places where we look for a package.json when tr…

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -75,10 +75,10 @@ export class GrabTypings {
         // generating the version string is kind of a pain because of where
         // we compile to. as such, we do some janky stuff here
         var VERSION_STR = "unknown";
-        if (fs.existsSync("./package.json")) {
-            VERSION_STR = JSON.parse(fs.readFileSync("./package.json").toString()).version;
-        } else if (fs.existsSync(__dirname + "/../../package.json")) {
+        if (fs.existsSync(__dirname + "/../../package.json")) {
             VERSION_STR = JSON.parse(fs.readFileSync(__dirname + "/../../package.json").toString()).version;
+        } else if (fs.existsSync("./package.json")) {
+            VERSION_STR = JSON.parse(fs.readFileSync("./package.json").toString()).version;
         }
         this.VERSION_STR = VERSION_STR;
         


### PR DESCRIPTION
…ying to read the version number. As it was, it had the side effect of grabbing the wrong number if you ran gt in a directory that had a package.json file...which was pretty much the most common place to want to run it.
